### PR TITLE
WIP: bring back stashed changes after green restore

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,4 +1,5 @@
 name: python-tests
+
 on:
   push:
     branches: [ "main" ]
@@ -15,19 +16,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install fastapi uvicorn pytest httpx python-dotenv pytest-cov
 
       - name: Run tests
         env:
           PYTHONPATH: .
-        run: pytest -q --cov=app --cov=bmi_core --cov-report=term-missing --cov-report=xml
+        run: |
+          pytest -q --maxfail=1 --cov=. --cov-report=term-missing --cov-report=xml
 
       - name: Upload coverage.xml
         uses: actions/upload-artifact@v4

--- a/tests_strict/test_api.py
+++ b/tests_strict/test_api.py
@@ -82,8 +82,8 @@ def test_bmi_en_athlete():
     assert r.status_code == 200
     data = r.json()
     assert data["group"] == "athlete"
-    assert ("Overweight" in data["category"] or
-            "Healthy weight" in data["category"])
+    category = data["category"]
+    assert ("Overweight" in category or "Healthy weight" in category)
 
 
 def test_bmi_missing_fields():

--- a/tests_strict/test_bmi_core.py
+++ b/tests_strict/test_bmi_core.py
@@ -126,7 +126,9 @@ def test_healthy_bmi_ranges_adult_elderly_sport():
 def test_build_premium_plan_maintain():
     # Подберём вес в «здоровом» диапазоне, чтобы действие было maintain
     height = 1.75
-    bmin, bmax = healthy_bmi_range(30, "general", premium=False)  # (18.5, 25.0)
+    bmin, bmax = healthy_bmi_range(
+        30, "general", premium=False
+    )  # (18.5, 25.0)
     wmin = round(bmin * height * height, 1)  # ~56.6
     wmax = round(bmax * height * height, 1)  # ~76.6
     weight = (wmin + wmax) / 2
@@ -138,7 +140,9 @@ def test_build_premium_plan_maintain():
 
 def test_build_premium_plan_lose():
     height = 1.70
-    bmin, bmax = healthy_bmi_range(35, "general", premium=False)  # (18.5, 25.0)
+    bmin, bmax = healthy_bmi_range(
+        35, "general", premium=False
+    )  # (18.5, 25.0)
     wmax = round(bmax * height * height, 1)
     weight = wmax + 5.0  # выше «здорового» → нужно снижать
     bmi = bmi_value(weight, height)
@@ -150,7 +154,9 @@ def test_build_premium_plan_lose():
 
 def test_build_premium_plan_gain():
     height = 1.60
-    bmin, bmax = healthy_bmi_range(25, "general", premium=False)  # (18.5, 25.0)
+    bmin, bmax = healthy_bmi_range(
+        25, "general", premium=False
+    )  # (18.5, 25.0)
     wmin = round(bmin * height * height, 1)
     weight = wmin - 3.0  # ниже «здорового» → нужно набирать
     bmi = bmi_value(weight, height)

--- a/tests_strict/test_bmi_core_dojim.py
+++ b/tests_strict/test_bmi_core_dojim.py
@@ -3,18 +3,9 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
-
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
-
 # -*- coding: utf-8 -*-
-"""Маленькие edge-тесты, которые добивают покрытие до ~99–100% при нашей версии ядра."""
+"""Маленькие edge-тесты, которые добивают покрытие до ~99–100%
+при нашей версии ядра."""
 from bmi_core import (
     bmi_value,
     build_premium_plan,
@@ -44,5 +35,7 @@ def test_build_premium_plan_gain_ru_tips():
     bmi = bmi_value(weight, height)
     plan = build_premium_plan(25, weight, height, bmi, "ru", "general", False)
     assert plan["action"] == "gain"
-    assert isinstance(plan["nutrition_tip"], str) and len(plan["nutrition_tip"]) > 0
-    assert isinstance(plan["activity_tip"], str) and len(plan["activity_tip"]) > 0
+    nutrition_tip = plan["nutrition_tip"]
+    activity_tip = plan["activity_tip"]
+    assert isinstance(nutrition_tip, str) and len(nutrition_tip) > 0
+    assert isinstance(activity_tip, str) and len(activity_tip) > 0

--- a/tests_strict/test_bmi_core_edges.py
+++ b/tests_strict/test_bmi_core_edges.py
@@ -3,16 +3,6 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
-
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
-
 # -*- coding: utf-8 -*-
 """Edge-тесты для доведения покрытия до ~100%."""
 from bmi_core import (
@@ -40,7 +30,8 @@ def test_interpret_group_general_ru_no_note():
 
 def test_auto_group_regex_phrase_sportswoman():
     # Слово внутри фразы, не точное совпадение -> сработает regex
-    assert auto_group(30, "жен", "нет", "я спортсменка, хожу в зал", "ru") == "athlete"
+    phrase = "я спортсменка, хожу в зал"
+    assert auto_group(30, "жен", "нет", phrase, "ru") == "athlete"
 
 
 def test_auto_group_pregnant_en():
@@ -75,7 +66,8 @@ def test_healthy_bmi_range_athlete_premium_raise():
 
 def test_premium_plan_maintain_has_none_weeks():
     height = 1.75
-    # Подберём вес в «здоровом» диапазоне, чтобы action=maintain и est_weeks=(None, None)
+    # Подберём вес в «здоровом» диапазоне, чтобы action=maintain
+    # и est_weeks=(None, None)
     bmin, bmax = healthy_bmi_range(30, "general", premium=False)
     wmin = round(bmin * height * height, 1)
     wmax = round(bmax * height * height, 1)

--- a/tests_strict/test_bmi_core_more_edges.py
+++ b/tests_strict/test_bmi_core_more_edges.py
@@ -4,7 +4,8 @@ import sys
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
 # -*- coding: utf-8 -*-
-"""Дополнительные edge-тесты: _validate_age error и ветка 'general' в auto_group."""
+"""Дополнительные edge-тесты: _validate_age error и ветка 'general'
+в auto_group."""
 import pytest
 
 from bmi_core import auto_group, bmi_value, build_premium_plan
@@ -14,7 +15,8 @@ def test_validate_age_raises_in_build_plan():
     # age=0 → _validate_age должен выбросить ValueError (строка 103)
     with pytest.raises(ValueError):
         # вес/рост валидные, чтобы дошло именно до проверки возраста
-        build_premium_plan(0, 70.0, 1.75, bmi_value(70.0, 1.75), "en", "general", False)
+        bmi = bmi_value(70.0, 1.75)
+        build_premium_plan(0, 70.0, 1.75, bmi, "en", "general", False)
 
 
 def test_auto_group_returns_general_branch():

--- a/tests_strict/test_bodyfat.py
+++ b/tests_strict/test_bodyfat.py
@@ -3,27 +3,9 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
-import pathlib
-import sys
+import math
 
 from bodyfat import bf_deurenberg, bf_us_navy, bf_ymca, estimate_all
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
-
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
-
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-import math
 
 
 def assert_percent(x):
@@ -46,7 +28,9 @@ def test_us_navy_male_smoke():
 
 
 def test_us_navy_female_smoke():
-    val = bf_us_navy(height_cm=170, neck_cm=34, waist_cm=74, hip_cm=94, gender="female")
+    val = bf_us_navy(
+        height_cm=170, neck_cm=34, waist_cm=74, hip_cm=94, gender="female"
+    )
     assert_percent(val)
 
 
@@ -78,7 +62,10 @@ def test_estimate_all_smoke():
     assert "methods" in res and isinstance(res["methods"], dict)
     # если хотя бы одна методика дала число — ок
     vals = list(res["methods"].values())
-    assert any(isinstance(v, (int, float)) and 0 < v < 100 for v in vals)
+    valid_vals = [
+        v for v in vals if isinstance(v, (int, float)) and 0 < v < 100
+    ]
+    assert len(valid_vals) > 0
     # если есть медиана — тоже должна быть корректным процентом
     if res.get("median") is not None:
         assert_percent(res["median"])

--- a/tools/patch_cleanup.py
+++ b/tools/patch_cleanup.py
@@ -1,0 +1,119 @@
+# ruff: noqa: E501
+# -*- coding: utf-8 -*-
+"""
+Чистим дубликаты эндпоинтов /insight и /api/v1/insight в app.py,
+возвращаем единую проверку X-API-Key для /api/v1/bmi и /api/v1/insight.
+"""
+import re
+from pathlib import Path
+
+p = Path("app.py")
+src = p.read_text(encoding="utf-8")
+
+changed = False
+
+def drop_route(func_name: str):
+    """
+    Удаляет блок вида:
+    @app.post("/...") [возможно с зависимостями/параметрами в декораторе в нескольких строках]
+    (async )def func_name(...):
+        <тело>
+    """
+    global src, changed
+    # Захват декоратора(ов) над нужной функцией и самого тела функции
+    pattern = rf"""
+(?P<decorators>(?:^[ \t]*@app\.post\(.*\)\s*\n)+)   # один или несколько декораторов @app.post
+^[ \t]*(?:async[ \t]+)?def[ \t]+{func_name}\s*\(.*?\):\s*\n   # сигнатура функции
+(?:^[ \t]+.*\n|^\n)*                                   # тело (грубо)
+"""
+    src2, n = re.subn(pattern, "", src, flags=re.MULTILINE | re.DOTALL | re.VERBOSE)
+    if n:
+        src = src2
+        changed = True
+
+# 1) Сносим старые реализации этих функций (если были)
+for fn in ("insight", "api_v1_insight"):
+    drop_route(fn)
+
+# 2) Импорты для зависимостей/моделей
+def ensure(line: str):
+    global src, changed
+    if line not in src:
+        src = line + "\n" + src
+        changed = True
+
+ensure("import os")
+ensure("import llm")
+ensure("from fastapi import FastAPI")
+ensure("from fastapi import HTTPException, Header, Depends")
+ensure("from pydantic import BaseModel")
+
+# 3) Убедимся, что есть app
+if "app = FastAPI(" not in src:
+    src += "\n\napp = FastAPI(title='BMI-App_2025')\n"
+    changed = True
+
+# 4) Добавим единый хэндлер инсайта (без дублей, с правильным порядком проверок)
+handler = r'''
+# --- Insight endpoints (single source of truth) ---
+class InsightIn(BaseModel):
+    text: str
+
+class InsightOut(BaseModel):
+    provider: str
+    result: str
+
+def _is_true(val: str) -> bool:
+    return str(val).lower() in {"1", "true", "yes", "on", "y"}
+
+def get_api_key(x_api_key: str | None = Header(default=None, alias="X-API-Key")) -> None:
+    expected = os.getenv("API_KEY", "test_key")
+    if not x_api_key or x_api_key != expected:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+@app.post("/insight", name="insight_post", response_model=InsightOut, dependencies=[Depends(get_api_key)])
+def insight(inp: InsightIn):
+    # 2) feature flag
+    if not _is_true(os.getenv("FEATURE_INSIGHT", "")):
+        raise HTTPException(status_code=503, detail="insight feature disabled")
+    # 3) provider
+    provider = llm.get_provider()
+    if provider is None:
+        raise HTTPException(status_code=503, detail="No LLM provider configured")
+    out = provider.generate(inp.text)
+    return {"provider": getattr(provider, "name", "unknown"), "result": out}
+
+@app.post("/api/v1/insight", name="api_v1_insight_post", response_model=InsightOut, dependencies=[Depends(get_api_key)])
+def api_v1_insight(inp: InsightIn):
+    return insight(inp)
+'''
+
+# Чистим нашу предыдущую вставку, если была (чтобы не плодить дубли при повторном запуске)
+src = re.sub(r"\n# --- Insight endpoints \(single source of truth\).*?\Z", "", src, flags=re.DOTALL)
+
+# 5) Добавляем свежий блок в конец
+src = src.rstrip() + "\n\n" + handler.strip() + "\n"
+changed = True
+
+# 6) Включаем Depends(get_api_key) для /api/v1/bmi если вдруг отсутствует
+# Ищем существующий декоратор и подставим зависимости, если их нет
+def add_depends_for_bmi():
+    global src, changed
+    pattern = r'(@app\.post\("/api/v1/bmi"(?!.*dependencies=)\s*(?:,.*)?\))'
+    def repl(m):
+        dec = m.group(1)
+        if dec.endswith(")"):
+            dec = dec[:-1] + ", dependencies=[Depends(get_api_key)])"
+        return dec
+    new_src, n = re.subn(pattern, repl, src, flags=re.DOTALL)
+    if n:
+        src = new_src
+        changed = True
+
+add_depends_for_bmi()
+
+if changed:
+    p.write_text(src, encoding="utf-8")
+    print("app.py cleaned & patched")
+else:
+    print("no changes")

--- a/tools/patch_health.py
+++ b/tools/patch_health.py
@@ -1,0 +1,61 @@
+# ruff: noqa: E501
+# -*- coding: utf-8 -*-
+"""
+Добавляем health-check эндпоинты:
+- GET /api/v1/health  -> 200 {"status":"ok"}
+- GET /health         -> 200 {"status":"ok"}
+Без проверки API-ключа. Идемпотентно: старые версии удаляем.
+"""
+import re
+from pathlib import Path
+
+p = Path("app.py")
+src = p.read_text(encoding="utf-8")
+
+changed = False
+
+def ensure(line: str):
+    global src, changed
+    if line not in src:
+        src = line + "\n" + src
+        changed = True
+
+# Импорты и наличие app
+ensure("from fastapi import FastAPI")
+ensure("from fastapi import HTTPException, Header, Depends")  # уже может быть
+ensure("from pydantic import BaseModel")  # уже может быть
+if "app = FastAPI(" not in src:
+    src += "\n\napp = FastAPI(title='BMI-App_2025')\n"
+    changed = True
+
+# Удаляем любые старые определения health
+pattern = r"""
+(^[ \t]*@app\.get\("/api/v1/health".*?\)\s*\n[ \t]*(?:async[ \t]+)?def[ \t]+[a-zA-Z_][a-zA-Z0-9_]*\(.*?\):\s*\n(?:^[ \t]+.*\n|^\n)*)
+|(^[ \t]*@app\.get\("/health".*?\)\s*\n[ \t]*(?:async[ \t]+)?def[ \t]+[a-zA-Z_][a-zA-Z0-9_]*\(.*?\):\s*\n(?:^[ \t]+.*\n|^\n)*)
+"""
+src2, n = re.subn(pattern, "", src, flags=re.MULTILINE | re.DOTALL | re.VERBOSE)
+if n:
+    src = src2
+    changed = True
+
+handler = r'''
+# --- Health endpoints ---
+@app.get("/api/v1/health", name="api_v1_health")
+def api_v1_health():
+    return {"status": "ok"}
+
+@app.get("/health", name="health")
+def health():
+    return {"status": "ok"}
+'''
+
+# Добавляем блок в конец
+if "# --- Health endpoints ---" not in src:
+    src = src.rstrip() + "\n\n" + handler.strip() + "\n"
+    changed = True
+
+if changed:
+    p.write_text(src, encoding="utf-8")
+    print("app.py: health endpoints added/updated")
+else:
+    print("no changes")

--- a/tools/patch_health.py
+++ b/tools/patch_health.py
@@ -14,16 +14,16 @@ src = p.read_text(encoding="utf-8")
 
 changed = False
 
-def ensure(line: str):
-    global src, changed
+def ensure(line: str, src: str, changed: bool):
     if line not in src:
         src = line + "\n" + src
         changed = True
+    return src, changed
 
 # Импорты и наличие app
-ensure("from fastapi import FastAPI")
-ensure("from fastapi import HTTPException, Header, Depends")  # уже может быть
-ensure("from pydantic import BaseModel")  # уже может быть
+src, changed = ensure("from fastapi import FastAPI", src, changed)
+src, changed = ensure("from fastapi import HTTPException, Header, Depends", src, changed)  # уже может быть
+src, changed = ensure("from pydantic import BaseModel", src, changed)  # уже может быть
 if "app = FastAPI(" not in src:
     src += "\n\napp = FastAPI(title='BMI-App_2025')\n"
     changed = True

--- a/tools/patch_insight.py
+++ b/tools/patch_insight.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""
+Patch app.py:
+- Ensure API key check (403) happens BEFORE feature flag and provider checks
+- Keep both /insight and /api/v1/insight
+- 503 messages:
+    * feature disabled -> "insight feature disabled"
+    * no provider      -> "No LLM provider configured"
+- Avoid duplicate operationId by setting unique 'name' in @app.post
+"""
+import re
+from pathlib import Path
+
+APP = Path("app.py")
+src = APP.read_text(encoding="utf-8")
+
+changed = False
+
+def ensure_import(line: str):
+    global src, changed
+    if line not in src:
+        src = line + "\n" + src
+        changed = True
+
+# Импорты
+ensure_import("import os")
+if "import llm" not in src:
+    # вставим рядом с другими import
+    m = re.search(r"(^|\n)(?:from\s+\S+\s+import\s+\S+|import\s+\S+)(?:.*\n)+", src)
+    if m:
+        src = src[:m.end()] + "import llm\n" + src[m.end():]
+    else:
+        ensure_import("import llm")
+
+if "from fastapi import FastAPI" not in src:
+    ensure_import("from fastapi import FastAPI")
+if "from fastapi import HTTPException" not in src:
+    ensure_import("from fastapi import HTTPException")
+if "from fastapi import Header" not in src:
+    ensure_import("from fastapi import Header")
+if "from pydantic import BaseModel" not in src:
+    ensure_import("from pydantic import BaseModel")
+
+# Убедимся, что есть app = FastAPI(...)
+if "app = FastAPI(" not in src:
+    src += "\n\napp = FastAPI(title='BMI-App_2025')\n"
+    changed = True
+
+# Удалим старые вставки инсайта (если были)
+src = re.sub(r"# --- Insight endpoints.*?(?=\n# ---|$)", "", src, flags=re.DOTALL)
+
+handler = r'''
+# --- Insight endpoints (idempotent patch) ---
+
+class InsightIn(BaseModel):
+    text: str
+
+class InsightOut(BaseModel):
+    provider: str
+    result: str
+
+def _is_true(val: str) -> bool:
+    return str(val).lower() in {"1", "true", "yes", "on", "y"}
+
+def _check_api_key(x_api_key: str | None) -> None:
+    expected = os.getenv("API_KEY", "test_key")
+    if not x_api_key or x_api_key != expected:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+@app.post("/insight", name="insight_post", response_model=InsightOut)
+def insight(
+    inp: InsightIn,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+):
+    # 1) API key
+    _check_api_key(x_api_key)
+
+    # 2) feature flag
+    if not _is_true(os.getenv("FEATURE_INSIGHT", "")):
+        raise HTTPException(status_code=503, detail="insight feature disabled")
+
+    # 3) provider
+    provider = llm.get_provider()
+    if provider is None:
+        raise HTTPException(status_code=503, detail="No LLM provider configured")
+
+    out = provider.generate(inp.text)
+    return {"provider": getattr(provider, "name", "unknown"), "result": out}
+
+@app.post("/api/v1/insight", name="api_v1_insight_post", response_model=InsightOut)
+def api_v1_insight(
+    inp: InsightIn,
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+):
+    return insight(inp, x_api_key=x_api_key)
+'''
+
+src = src.rstrip() + "\n\n" + handler.strip() + "\n"
+changed = True
+
+APP.write_text(src, encoding="utf-8")
+print("app.py patched")

--- a/tools/patch_insight.py
+++ b/tools/patch_insight.py
@@ -25,9 +25,9 @@ def ensure_import(line: str):
 # Импорты
 ensure_import("import os")
 if "import llm" not in src:
-    # вставим рядом с другими import
-    m = re.search(r"(^|\n)(?:from\s+\S+\s+import\s+\S+|import\s+\S+)(?:.*\n)+", src)
-    if m:
+    if m := re.search(
+        r"(^|\n)(?:from\s+\S+\s+import\s+\S+|import\s+\S+)(?:.*\n)+", src
+    ):
         src = src[:m.end()] + "import llm\n" + src[m.end():]
     else:
         ensure_import("import llm")


### PR DESCRIPTION
Ветка собрана поверх restore/green-584f7f1.
- Вернула изменения из stash (workflow + patch_* scripts)
- Оставлены зелёные версии app.py, llm.py, tests/conftest.py
- Добавлены patch_insight/cleanup/health для повторного использования
- Заглушен Ruff E501 в скриптах

Все тесты проходят (103 passed, 8 skipped), Ruff чистый.
Дальше можно точечно возвращать нужные изменения.

## Summary by Sourcery

Restore stashed workflow changes and introduce idempotent patch scripts for insight and health endpoints, update CI to Python 3.13 with improved test command, and ensure linting warnings are silenced

New Features:
- Add patch_cleanup.py for deduplicating insight endpoints and enforcing unified API key checks
- Add patch_insight.py to apply idempotent insight endpoint patches with proper API key, feature flag, and provider checks
- Add patch_health.py to implement idempotent health-check endpoints at /health and /api/v1/health

Enhancements:
- Reinstate previously stashed workflow and patch scripts for endpoint management
- Silence Ruff E501 warnings in new patch scripts

CI:
- Bump Python version to 3.13 in GitHub Actions and refine pytest invocation options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GET /health and GET /api/v1/health (status: ok).
  - POST /insight and POST /api/v1/insight with structured responses; respects feature flag and returns clear errors when unavailable.
  - Standardized API-key protection applied to BMI and Insight endpoints.

- **Chores**
  - CI: run tests on PRs to main, upgraded to Python 3.13, simplified dependency setup, fail-fast pytest with repo-wide coverage.

- **Tests**
  - Multiple test cleanups and readability/validation improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->