### PR TITLE
Handle sync insight providers and stabilize insight tests

### DIFF
--- a/tests/test_property_based.py
+++ b/tests/test_property_based.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from hypothesis import assume, given
 from hypothesis import strategies as st
+from hypothesis import settings, HealthCheck
 
 try:
     from app import app as fastapi_app  # type: ignore
@@ -150,6 +151,7 @@ def test_api_bmi_property(weight, height):
 
 
 @given(text=st.text(min_size=1, max_size=100))
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_api_insight_property(monkeypatch, text):
     """Test /api/v1/insight endpoint with random text inputs."""
     monkeypatch.setattr(llm, "get_provider", lambda: _StubProvider())


### PR DESCRIPTION
## Summary
- Support synchronous insight providers in API and /insight endpoint
- Adjust insight feature flag and provider checks
- Suppress Hypothesis fixture health check in property-based test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b560c1ec908333a7c726968fd53830

## Summary by Sourcery

Enable sync and async insight providers, refine the insight feature flag behavior, and stabilize the property-based insight tests by suppressing Hypothesis health checks

New Features:
- Support synchronous insight providers in both API endpoints

Enhancements:
- Update feature flag logic to disable insights only on explicit off values
- Refine insight provider error handling for consistent HTTP responses

Tests:
- Suppress Hypothesis function-scoped fixture health check in the property-based insight test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Insight endpoints now support both synchronous and asynchronous provider responses for broader compatibility.
* Bug Fixes
  * Updated feature flag behavior for Insight: enabled by default unless explicitly set to 0/false/off/no, ensuring more predictable configuration.
* Refactor
  * Aligned async handling across v1 and non-v1 Insight endpoints for consistent behavior.
* Tests
  * Adjusted property-based test settings to reduce flakiness and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->