### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,4 +1,6 @@
 name: python-tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Katsiarynakavaleuskaya/BMI-App_2025_clean/security/code-scanning/3](https://github.com/Katsiarynakavaleuskaya/BMI-App_2025_clean/security/code-scanning/3)

To fix this problem, you should add a `permissions` block to the workflow. The safest and most future-proof place to do this is at the top level of the YAML workflow file (i.e., alongside `name:` and `on:`), so all jobs inherit these minimal permissions unless they specifically override them. The minimal recommended permissions for workflows that only check out code, set up dependencies, run tests, and upload artifacts is typically `contents: read`, which allows read access to the repository contents with no write privileges. Add:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` entries at the top of the `.github/workflows/python-tests.yml` file. No new dependencies or additional code are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add top-level permissions block with contents: read to python-tests workflow